### PR TITLE
Upgrade to 1.4.4

### DIFF
--- a/Localization/en-US_Mods.BetterZoom.hjson
+++ b/Localization/en-US_Mods.BetterZoom.hjson
@@ -1,0 +1,33 @@
+Configs: {
+	Config: {
+		maxZoom: {
+			Tooltip:
+				'''
+				This changes the maximal amount of zoom you can set
+				You need to set this in the mod menu, since it requires a reload
+				'''
+			Label: Max Zoom
+		}
+
+		minZoom: {
+			Tooltip:
+				'''
+				This changes the minimum amount of zoom you can set
+				You need to set this in the mod menu, since it requires a reload
+				'''
+			Label: Min Zoom
+		}
+
+		cursorScale: {
+			Tooltip: This changes the size of your cursor
+			Label: Cursor Scale
+		}
+
+		scaleBackground: {
+			Tooltip: This toggles if the background should zoom too
+			Label: Scale Background
+		}
+
+		DisplayName: Config
+	}
+}

--- a/src/Edits/SettingsEdits.cs
+++ b/src/Edits/SettingsEdits.cs
@@ -17,7 +17,7 @@ internal static class SettingsEdits
 {
 	public static void Load()
 	{
-		IL.Terraria.IngameOptions.Draw += IngameOptions_Draw;
+		IL_IngameOptions.Draw += IngameOptions_Draw;
 	}
 
 	private static void IngameOptions_Draw(ILContext il)

--- a/src/Edits/ZoomEdits.cs
+++ b/src/Edits/ZoomEdits.cs
@@ -14,44 +14,52 @@ internal static class ZoomEdits
 
 	private static readonly MethodInfo m_UIScaleMax = typeof(Main).GetMethod("get_UIScaleMax", BindingFlags.Public | BindingFlags.Instance);
 
-	internal static event hook_get_UIScaleMax On_get_UIScaleMax {
-		add => HookEndpointManager.Add(m_UIScaleMax, value);
-		remove => HookEndpointManager.Remove(m_UIScaleMax, value);
+	internal static event hook_get_UIScaleMax On_get_UIScaleMax
+	{
+		add => Terraria.ModLoader.MonoModHooks.Add(m_UIScaleMax, value);
+		remove => Terraria.ModLoader.MonoModHooks.Modify(m_UIScaleMax, null); // TODO: Check this
 	}
 
 	public static void Load()
 	{
-		On.Terraria.Main.UpdateViewZoomKeys += Main_UpdateViewZoomKeys;
-		IL.Terraria.Main.DoDraw += ModifyZoomBounds;
+		On_Main.UpdateViewZoomKeys += Main_UpdateViewZoomKeys;
+		IL_Main.DoDraw += ModifyZoomBounds;
 		On_get_UIScaleMax += ModifyUIScaleBounds;
 	}
 
-	private static void Main_UpdateViewZoomKeys(On.Terraria.Main.orig_UpdateViewZoomKeys orig, Main self)
+	private static void Main_UpdateViewZoomKeys(On_Main.orig_UpdateViewZoomKeys orig, Main self)
 	{
-		if (Main.inFancyUI) {
+		if (Main.inFancyUI)
+		{
 			return;
 		}
 
 		float num = 0.01f * Main.GameZoomTarget; // changed
 
-		if (!Main.keyState.PressingShift()) { // <new />
-			if (PlayerInput.Triggers.Current.ViewZoomIn) {
+		if (!Main.keyState.PressingShift())
+		{ // <new />
+			if (PlayerInput.Triggers.Current.ViewZoomIn)
+			{
 				Main.GameZoomTarget = Utils.Clamp(Main.GameZoomTarget + num, BetterZoom.MinGameZoom, BetterZoom.MaxGameZoom); // changed
 			}
 
-			if (PlayerInput.Triggers.Current.ViewZoomOut) {
+			if (PlayerInput.Triggers.Current.ViewZoomOut)
+			{
 				Main.GameZoomTarget = Utils.Clamp(Main.GameZoomTarget - num, BetterZoom.MinGameZoom, BetterZoom.MaxGameZoom); // changed
 			}
 		}
 		// <new>
-		else {
+		else
+		{
 			float num1 = 0.01f * Main.UIScale;
-			if (PlayerInput.Triggers.Current.ViewZoomIn) {
+			if (PlayerInput.Triggers.Current.ViewZoomIn)
+			{
 				Main.UIScale = Utils.Clamp(Main.UIScale + num1, BetterZoom.MIN_UI_ZOOM, BetterZoom.MAX_UI_ZOOM);
 				Main.temporaryGUIScaleSlider = Main.UIScale;
 			}
 
-			if (PlayerInput.Triggers.Current.ViewZoomOut) {
+			if (PlayerInput.Triggers.Current.ViewZoomOut)
+			{
 				Main.UIScale = Utils.Clamp(Main.UIScale - num1, BetterZoom.MIN_UI_ZOOM, BetterZoom.MAX_UI_ZOOM);
 				Main.temporaryGUIScaleSlider = Main.UIScale;
 			}
@@ -95,7 +103,8 @@ internal static class ZoomEdits
 			i => i.MatchLdsfld<Main>("GameViewMatrix"),
 			i => i.MatchLdsfld<Main>("ForcedMinimumZoom"),
 			i => i.MatchLdsfld<Main>("GameZoomTarget"),
-			i => i.MatchLdcR4(1))) {
+			i => i.MatchLdcR4(1)))
+		{
 			throw new ILEditException($"BetterZoom.{nameof(ZoomEdits)}::{nameof(ModifyZoomBounds)}");
 		}
 


### PR DESCRIPTION
Honestly, I have a fairly limited understanding of Dotnet in general. 
There's one line that concerns me: 

Going from: 
```
	internal static event hook_get_UIScaleMax On_get_UIScaleMax {
		add => HookEndpointManager.Add(m_UIScaleMax, value);
		remove => HookEndpointManager.Remove(m_UIScaleMax, value);
	}
```

to:

```
	internal static event hook_get_UIScaleMax On_get_UIScaleMax
	{
		add => Terraria.ModLoader.MonoModHooks.Add(m_UIScaleMax, value);
		remove => Terraria.ModLoader.MonoModHooks.Modify(m_UIScaleMax, null); // TODO: Check this
	}
```

MonoModHooks doesn't seem to have a remove method anymore, but that being said, this all does work for myself.

Worth noting that there are some deprecations, in particular with regards to the TooltipAttribute which is all now localized, this doesn't fix those warnings.
